### PR TITLE
Add operator support for QuickBooksResource->query

### DIFF
--- a/src/QuickBooksResource.php
+++ b/src/QuickBooksResource.php
@@ -240,9 +240,41 @@ class QuickBooksResource
         $where  = ' WHERE ';
 
         $where .= collect($attributes)->map(function ($value, $key) {
+            if ($this->isAdvancedQuery($value)) {
+                return $this->buildAdvancedWhereString($value);
+            }
             return "$key = '" . addslashes($value) . "'";
         })->implode(' AND ');
 
         return $where;
+    }
+
+    /**
+     * Builds a where clause that allows for operators other than =
+     *
+     * @param array $value
+     * @param string $key
+     * @return string
+     */
+    protected function buildAdvancedWhereString($attributes)
+    {
+        $operators = ["=", "<=", "<", ">=", ">"];
+
+        [$table, $operator, $value] = $attributes;
+
+        if (! in_array($operator, $operators)) throw new \InvalidArgumentException("Invalid Operator");
+
+        return "$table $operator '". addslashes($value)."'";
+    }
+
+    /**
+     * Determine if the query attribute has operators
+     *
+     * @param array $attributes
+     * @return boolean
+     */
+    protected function isAdvancedQuery($attributes)
+    {
+        return count($attributes) === 3;
     }
 }


### PR DESCRIPTION
Add support for operators in the QuickBooksResource->query() method, originally query syntax was Customer->query(["key" => "value"]) which produced a where clause like `WHERE key = 'value'`, (this remains supported), but an additional syntax allows for using operators other than `=`. Example: Customer->query(["key", ">", "value"]) produces a where clause like `WHERE key > 'value'`, implosion of multiple clauses with "AND" is also still supported