### PR TITLE
Replace str_random with Str::random

### DIFF
--- a/src/QuickBooksAuthenticator.php
+++ b/src/QuickBooksAuthenticator.php
@@ -4,6 +4,7 @@ namespace LifeOnScreen\LaravelQuickBooks;
 
 use Exception;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\Request;
@@ -23,7 +24,7 @@ class QuickBooksAuthenticator
     public static function getAuthorizationUrl(): string
     {
         $cookieLife  = 30;
-        $cookieValue = str_random(32);
+        $cookieValue = Str::random(32);
         $validUntil  = Carbon::now()->addMinutes($cookieLife)->timestamp;
         Cookie::queue(Cookie::make('quickbooks_auth', $cookieValue, $cookieLife));
         cache(['qb-auth-cookie' => "{$cookieValue}|{$validUntil}"], $cookieLife);


### PR DESCRIPTION
string helper functions are no longer supported as of Laravel 6, replaced with Str facade